### PR TITLE
Cube file printing modifications

### DIFF
--- a/src/BOSampleStepper.C
+++ b/src/BOSampleStepper.C
@@ -1459,7 +1459,7 @@ void BOSampleStepper::step(int niter)
                      for (int jj = 0; jj < np1; jj++) {
                         const int jp = (jj + np1/2) % np1;
                         for (int kk = 0; kk < np2; kk++) {
-                           const int kp = (KK + np2/2) % np2;
+                           const int kp = (kk + np2/2) % np2;
                            int index = ip + jp*np0 + kp*np0*np1;
                            oss << tmprecv[index] << " ";
                            cnt++;

--- a/src/BOSampleStepper.C
+++ b/src/BOSampleStepper.C
@@ -1432,8 +1432,7 @@ void BOSampleStepper::step(int niter)
                            natoms_total += as.na(is);
                         }
                         as.get_positions(rion,true);
-                        D3vector origin(0.0,0.0,0.0);
-                        os << natoms_total << " " << origin << endl;
+                        os << natoms_total << " " << -0.5*(a0+a1+a2) << endl;
 
                         // print FFT grid info
                         os << np0 << " " << dft0 << endl;
@@ -1453,12 +1452,15 @@ void BOSampleStepper::step(int niter)
                   // write density data to file
                   int cnt = 0;
                   for (int ii = 0; ii < np0; ii++) {
+                     const int ip = (ii + np0/2) % np0;
                      ostringstream oss;
                      oss.setf(ios::scientific,ios::floatfield);
                      oss << setprecision(5);
                      for (int jj = 0; jj < np1; jj++) {
+                        const int jp = (jj + np1/2) % np1;
                         for (int kk = 0; kk < np2; kk++) {
-                           int index = ii + jj*np0 + kk*np0*np1;
+                           const int kp = (KK + np2/2) % np2;
+                           int index = ip + jp*np0 + kp*np0*np1;
                            oss << tmprecv[index] << " ";
                            cnt++;
                            if (cnt >= 6) {

--- a/src/EhrenSampleStepper.C
+++ b/src/EhrenSampleStepper.C
@@ -1203,8 +1203,7 @@ void EhrenSampleStepper::step(int niter)
                          natoms_total += as.na(is);
                       }
                       as.get_positions(rion,true);
-                      D3vector origin(0.0,0.0,0.0);
-                      os << natoms_total << " " << origin << endl;
+                      os << natoms_total << " " << -0.5*(a0+a1+a2) << endl;
                       
                       // print FFT grid info
                       os << np0 << " " << dft0 << endl;
@@ -1224,12 +1223,15 @@ void EhrenSampleStepper::step(int niter)
                 // write density data to file
                 int cnt = 0;
                 for (int ii = 0; ii < np0; ii++) {
+		   const int ip = (ii + np0/2) % np0;
                    ostringstream oss;
                    oss.setf(ios::scientific,ios::floatfield);
                    oss << setprecision(5);
                    for (int jj = 0; jj < np1; jj++) {
+		      const int jp = (jj + np1/2) % np1;
                       for (int kk = 0; kk < np2; kk++) {
-                         int index = ii + jj*np0 + kk*np0*np1;
+			 const int kp = (kk + np2/2) % np2;
+                         int index = ip + jp*np0 + kp*np0*np1;
                          oss << tmprecv[index] << " ";
                          cnt++;
                          if (cnt >= 6) {

--- a/src/SaveCmd.C
+++ b/src/SaveCmd.C
@@ -748,8 +748,7 @@ int SaveCmd::action(int argc, char **argv) {
               natoms_total += as.na(is);
             }
             as.get_positions(rion,true);
-            D3vector origin(0.0,0.0,0.0);
-            os << natoms_total << " " << origin << endl;
+            os << natoms_total << " " << -0.5*(a0+a1+a2) << endl;
 
             // print FFT grid info
             os << np0 << " " << dft0 << endl;
@@ -769,12 +768,15 @@ int SaveCmd::action(int argc, char **argv) {
         // write density data to file
         int cnt = 0;
         for (int ii = 0; ii < np0; ii++) {
+	  const ip = (ii + np0/2) % np0;
           ostringstream oss;
           oss.setf(ios::scientific,ios::floatfield);
           oss << setprecision(5);
           for (int jj = 0; jj < np1; jj++) {
+	    const jp = (jj + np1/2) % np1;
             for (int kk = 0; kk < np2; kk++) {
-              int index = ii + jj*np0 + kk*np0*np1;
+	      const kp = (kk + np2/2) % np2;
+              int index = ip + jp*np0 + kp*np0*np1;
               oss << tmprecv[index] << " ";
               cnt++;
               if (cnt >= 6) {


### PR DESCRIPTION
Modified origin coordinates printed to cube file so that atoms are correctly centered in the cell.  Also modified cube file print loops so that charge density voxel data prints in the correct order, giving correct representation of charge density in real space. Modifications were based off of the correct printing scheme found in PlotCmd.C