### PR TITLE
disambiguate byte, colliding with new std::byte

### DIFF
--- a/src/qball/Base64Transcoder.cc
+++ b/src/qball/Base64Transcoder.cc
@@ -74,8 +74,10 @@ Base64Transcoder::Base64Transcoder()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int Base64Transcoder::encode(int nbytes, const byte* const from, char* const to)
+int Base64Transcoder::encode(int nbytes, const ::byte* const from, char* const to)
 {
+  using ::byte;
+  
   const byte* fptr = from;
   char* tptr = to;
   
@@ -122,7 +124,7 @@ int Base64Transcoder::encode(int nbytes, const byte* const from, char* const to)
 
 ////////////////////////////////////////////////////////////////////////////////
 int Base64Transcoder::decode(const int nchars, const char* const from, 
-  byte* const to)  
+  ::byte* const to)  
 {
   // Decode Base64 chars in array "from" into bytes in array "to"
   // White space and new lines are skipped
@@ -130,7 +132,9 @@ int Base64Transcoder::decode(const int nchars, const char* const from,
   // ignored.
   // nchars: number of chars in array "from"
   // the number of bytes successfully translated is returned
-  
+
+  using ::byte;
+
   byte a0,a1,a2,a3,b0,b1,b2,b3;
   int c;
   const char* fptr = from;

--- a/src/qball/Base64Transcoder.h
+++ b/src/qball/Base64Transcoder.h
@@ -40,13 +40,13 @@ typedef unsigned char byte;
 class Base64Transcoder
 {
   char etable[64];  // encode table
-  byte dtable[256]; // decode table
+  ::byte dtable[256]; // decode table
 
   public:
   
   Base64Transcoder();
-  int encode(int nbytes, const byte* const from, char* const to);
-  int decode(int nchars, const char* const from, byte* const to);
+  int encode(int nbytes, const ::byte* const from, char* const to);
+  int decode(int nchars, const char* const from, ::byte* const to);
   void byteswap_double(size_t n, double* const x);
   void byteswap_int(size_t n, int* const x);
   int print(int nchars, const char* const buf, ostream& o);

--- a/src/qball/SlaterDet.cc
+++ b/src/qball/SlaterDet.cc
@@ -2886,7 +2886,7 @@ void SlaterDet::print(ostream& os, string encoding) {
         int outlen = xcdr.nchars(nbytes);
         char* b = new char[outlen];
         assert(b!=0);
-        xcdr.encode(nbytes,(byte*) &wftmpr[0],b);
+        xcdr.encode(nbytes,(::byte*) &wftmpr[0],b);
         // Note: optional x0,y0,z0 attributes not used, default is zero
         os << "<grid_function type=\"double\""
            << " nx=\"" << ft.np0()
@@ -3146,7 +3146,7 @@ void SlaterDet::write(SharedFilePtr& sfp, string encoding, double weight, int is
           int outlen = xcdr.nchars(nbytes);
           char* b = new char[outlen];
           assert(b!=0);
-          xcdr.encode(nbytes,(byte*) &tmpr[0],b);
+          xcdr.encode(nbytes,(::byte*) &tmpr[0],b);
           // Note: optional x0,y0,z0 attributes not used, default is zero
           if ( ctxt_.myrow() == 0 )
             {


### PR DESCRIPTION
std::byte is declared by the standard library now.
Since qball uses `using namespace std;` everywhere, these name collisions happen. 

The changes disambiguate the use of `byte` using `::byte`.

I tested it with GCC 13 with no flags and with the "-std=c++11" flag (`CXX="mpicxx -std=c++11`).
 